### PR TITLE
Fix YAML parsing in check-new-releases workflow

### DIFF
--- a/.github/workflows/check-new-releases.yml
+++ b/.github/workflows/check-new-releases.yml
@@ -109,38 +109,40 @@ jobs:
           
           gh issue create \
             --title "Alloy ${VERSION} sysext build triggered" \
-            --body "## Automated Build Triggered
+            --body "$(cat <<EOF
+          ## Automated Build Triggered
 
-A new Grafana Alloy release was detected and a sysext build has been triggered.
+          A new Grafana Alloy release was detected and a sysext build has been triggered.
 
-**Version:** ${VERSION}
-**Release:** https://github.com/grafana/alloy/releases/tag/v${VERSION}
+          **Version:** ${VERSION}
+          **Release:** https://github.com/grafana/alloy/releases/tag/v${VERSION}
 
-### Release Notes (excerpt)
+          ### Release Notes (excerpt)
 
-${RELEASE_NOTES}
+          ${RELEASE_NOTES}
 
----
+          ---
 
-### Automated Pipeline
+          ### Automated Pipeline
 
-The build workflow will:
-1. Build the sysext image
-2. Upload to R2
-3. **Create a PR in ghost-stack** to update ghost.bu
+          The build workflow will:
+          1. Build the sysext image
+          2. Upload to R2
+          3. **Create a PR in ghost-stack** to update ghost.bu
 
-### Next Steps
+          ### Next Steps
 
-1. Wait for the build workflow to complete
-2. Review and merge the auto-generated ghost-stack PR
-3. Verify Alloy on the instance after deployment
+          1. Wait for the build workflow to complete
+          2. Review and merge the auto-generated ghost-stack PR
+          3. Verify Alloy on the instance after deployment
 
-### Files
+          ### Files
 
-Once built, the sysext will be available at:
-- \`https://ghost-sysext-images.separationofconcerns.dev/alloy-${VERSION}-amd64.raw\`
-- \`https://ghost-sysext-images.separationofconcerns.dev/alloy-${VERSION}-amd64.raw.sha256\`
-"
+          Once built, the sysext will be available at:
+          - https://ghost-sysext-images.separationofconcerns.dev/alloy-${VERSION}-amd64.raw
+          - https://ghost-sysext-images.separationofconcerns.dev/alloy-${VERSION}-amd64.raw.sha256
+          EOF
+          )"
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary

- Fix YAML parsing error that prevented the workflow from being recognized

## Problem

The multiline `--body` string in `gh issue create` was causing YAML parsing issues, resulting in:
- Workflow showing as file path instead of friendly name
- No "Run workflow" button available
- GitHub Actions validation error on line 114

## Fix

Use heredoc syntax `$(cat <<EOF ... EOF)` for the issue body, which properly delimits the multiline content and avoids YAML parser confusion.

## Test plan

- [x] Merge PR
- [x] Verify workflow shows as "Check for New Alloy Releases" in Actions
- [x] Verify "Run workflow" button appears