### PR TITLE
[GHO-38] Fix handling when no releases exist

### DIFF
--- a/.github/workflows/check-new-releases.yml
+++ b/.github/workflows/check-new-releases.yml
@@ -29,10 +29,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Get latest release tag from this repo (tracks last built version)
-          CURRENT_VERSION=$(gh api repos/${{ github.repository }}/releases/latest \
-            --jq '.tag_name' 2>/dev/null | sed 's/^v//' || echo "0.0.0")
+          # Use --silent to suppress errors, check if response contains tag_name
+          RESPONSE=$(gh api repos/${{ github.repository }}/releases/latest 2>/dev/null || echo '{}')
 
-          if [ -z "$CURRENT_VERSION" ] || [ "$CURRENT_VERSION" = "null" ]; then
+          if echo "$RESPONSE" | jq -e '.tag_name' > /dev/null 2>&1; then
+            CURRENT_VERSION=$(echo "$RESPONSE" | jq -r '.tag_name' | sed 's/^v//')
+          else
+            # No releases yet
             CURRENT_VERSION="0.0.0"
           fi
 


### PR DESCRIPTION
## Summary

- Fix error when no releases exist in the repository

## Problem

When querying for the latest release and none exist, `gh api` returns a 404 JSON response but exits with code 0. The previous code tried to parse this JSON as if it contained a tag_name, resulting in:

```
{"message":"Not Found","documentation_url":"...","status":"404"}
```

Being treated as shell command input.

## Fix

- Capture the full API response
- Use `jq -e` to check if `tag_name` exists before parsing
- Return `0.0.0` when no releases exist

## Test plan

- [x] Merge PR
- [x] Run check-new-releases workflow
- [ ] Verify it detects 0.0.0 as current version and creates a release for 1.13.0