### PR TITLE
[GHO-38] Add issues:write permission for tracking issue creation

### DIFF
--- a/.github/workflows/check-new-releases.yml
+++ b/.github/workflows/check-new-releases.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: write
       actions: write
+      issues: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Add missing `issues: write` permission to create tracking issues

## Problem

The workflow failed with:
```
GraphQL: Resource not accessible by integration (createIssue)
```

## Fix

Add `issues: write` to the job permissions.

## Test plan

- [x] Merge PR
- [ ] Re-run check-new-releases workflow
- [ ] Verify tracking issue is created