### PR TITLE
[GHO-38] Trigger build workflow directly via workflow_dispatch

### DIFF
--- a/.github/workflows/check-new-releases.yml
+++ b/.github/workflows/check-new-releases.yml
@@ -95,20 +95,36 @@ jobs:
           # Save to file to avoid shell escaping issues
           echo "$NOTES" > /tmp/release_notes.txt
 
-      - name: Create release to trigger build
+      - name: Create release
         if: steps.compare.outputs.update_available == 'true' && inputs.dry_run != true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ steps.latest.outputs.version }}"
 
-          echo "Creating release v${VERSION} to trigger build workflow"
+          echo "Creating release v${VERSION}"
 
           gh release create "v${VERSION}" \
             --title "Alloy Sysext ${VERSION}" \
             --notes-file /tmp/release_notes.txt
 
-          echo "Release created - build workflow will be triggered automatically"
+          echo "Release created"
+
+      - name: Trigger build workflow
+        if: steps.compare.outputs.update_available == 'true' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.latest.outputs.version }}"
+
+          echo "Triggering build-and-publish workflow for ${VERSION}"
+
+          # Trigger via workflow_dispatch since releases created by GITHUB_TOKEN
+          # don't trigger other workflows (GitHub security feature)
+          gh workflow run build-and-publish.yml \
+            --field version="${VERSION}"
+
+          echo "Build workflow triggered"
 
       - name: Create tracking issue
         if: steps.compare.outputs.update_available == 'true' && inputs.dry_run != true


### PR DESCRIPTION
## Summary

- Explicitly trigger build-and-publish workflow after creating release

## Problem

Releases created by `GITHUB_TOKEN` don't trigger other workflows. This is a GitHub security feature to prevent infinite workflow loops.

## Solution

After creating the release (for version tracking), explicitly trigger the build-and-publish workflow via `gh workflow run`.

## Test plan

- [x] Merge PR
- [x] Delete v1.13.0 release and tag
- [ ] Re-run check-new-releases workflow
- [ ] Verify build-and-publish workflow is triggered