### PR TITLE
[GHO-38] Use GitHub App token for ghost-stack PR creation

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -200,9 +200,18 @@ jobs:
           echo "sha256=${HASH}" >> $GITHUB_OUTPUT
           echo "SHA256 hash: ${HASH}"
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: noahwhite
+          repositories: ghost-stack
+
       - name: Create ghost-stack PR
         env:
-          GH_TOKEN: ${{ secrets.GHOST_STACK_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           VERSION="${{ needs.build.outputs.version }}"
           HASH="${{ steps.hash.outputs.sha256 }}"


### PR DESCRIPTION
## Summary

- Use GitHub App installation token for creating ghost-stack PRs

## Changes

- Add step to generate GitHub App token using `actions/create-github-app-token@v1`
- Use the app token instead of `GHOST_STACK_PAT` for API calls

## Why

Commits created via the GitHub API with a GitHub App token are automatically signed/verified by GitHub. This satisfies the verified signature requirement on ghost-stack branches.

## Prerequisites

- GitHub App `alloy-sysext-automation` created and installed on ghost-stack
- Secrets added to alloy-sysext-build:
  - `APP_ID`
  - `APP_PRIVATE_KEY`

## Test plan

- [x] Merge PR
- [x] Delete v1.13.0 release and tag
- [ ] Re-run check-new-releases workflow
- [ ] Verify ghost-stack PR is created with verified commit