### PR TITLE
fix: handle existing branch in ghost-stack PR creation

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -225,6 +225,13 @@ jobs:
           DEVELOP_SHA=$(gh api repos/${REPO}/git/ref/heads/develop --jq '.object.sha')
           echo "Develop branch SHA: ${DEVELOP_SHA}"
 
+          # Delete branch if it already exists (from previous failed attempt)
+          echo "Checking if branch ${BRANCH} already exists..."
+          if gh api repos/${REPO}/git/refs/heads/${BRANCH} --silent 2>/dev/null; then
+            echo "Branch exists, deleting it..."
+            gh api repos/${REPO}/git/refs/heads/${BRANCH} --method DELETE
+          fi
+
           # Create feature branch from develop using the API
           echo "Creating branch ${BRANCH}..."
           gh api repos/${REPO}/git/refs \


### PR DESCRIPTION
## Summary

- Adds check for existing branch before attempting to create it
- Deletes existing branch if found (from previous failed attempt)
- Prevents "Reference already exists" error on workflow retries

## Context

When the workflow fails after creating the branch in ghost-stack but before completing the PR, the branch remains. On retry, the workflow would fail with:

```
{"message":"Reference already exists","documentation_url":"https://docs.github.com/rest/git/refs#create-a-reference","status":"422"}
```

This fix handles that scenario gracefully by deleting the existing branch before creating a new one.

## Test plan

- [ ] Manually trigger the check-new-releases workflow
- [ ] Verify the build-and-publish workflow completes successfully
- [ ] Verify the ghost-stack PR is created with verified commit