### PR TITLE
fix: extract PR number from URL for assignment

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -320,7 +320,8 @@ jobs:
           echo "PR created: ${PR_URL}"
 
           # Assign PR to Noah White
-          PR_NUMBER=$(gh pr view --repo ${REPO} --json number -q '.number')
+          # Extract PR number from URL (format: https://github.com/owner/repo/pull/123)
+          PR_NUMBER=$(echo "${PR_URL}" | grep -oP 'pull/\K\d+')
           gh api repos/${REPO}/issues/${PR_NUMBER} \
             --method PATCH \
             --field assignees[]="noahwhite"


### PR DESCRIPTION
## Summary

- Fixes PR assignment step in ghost-stack PR creation
- Extracts PR number from `gh pr create` output URL instead of using `gh pr view`

## Context

The `gh pr view --repo` command requires a PR number or branch to be specified. The previous approach didn't provide one, causing the error:

```
argument required when using the --repo flag
```

Now extracts the PR number directly from the `gh pr create` output URL (format: `https://github.com/owner/repo/pull/123`).

## Test plan

- [ ] Verify the ghost-stack PR #114 was created successfully (it was, just assignment failed)
- [ ] Merge this fix
- [ ] On next run, verify PR is created AND assigned to noahwhite