### PR TITLE
fix: remove leading whitespace from PR body for interactive checkboxes

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -288,34 +288,33 @@ jobs:
 
           # Create PR
           echo "Creating pull request..."
+          PR_BODY="## Summary
+
+- Updates Grafana Alloy sysext from ${CURRENT_VERSION} to ${VERSION}
+- Updates SHA256 hash to \`${HASH}\`
+
+## Automated PR
+
+This PR was automatically created by the alloy-sysext-build CI pipeline after successfully building and publishing Alloy ${VERSION}.
+
+## Test plan
+
+- [ ] Review the version and hash changes in ghost.bu
+- [ ] Merge PR to trigger deployment
+- [ ] Verify Alloy version on instance: \`alloy --version\`
+- [ ] Verify Alloy service status: \`systemctl status alloy\`
+
+## Related
+
+- [Alloy Release](https://github.com/grafana/alloy/releases/tag/v${VERSION})
+- [Sysext Image](https://ghost-sysext-images.separationofconcerns.dev/alloy-${VERSION}-amd64.raw)"
+
           PR_URL=$(gh pr create \
             --repo ${REPO} \
             --base develop \
             --head "${BRANCH}" \
             --title "Update Grafana Alloy sysext to ${VERSION}" \
-            --body "$(cat <<EOF
-          ## Summary
-
-          - Updates Grafana Alloy sysext from ${CURRENT_VERSION} to ${VERSION}
-          - Updates SHA256 hash to \`${HASH}\`
-
-          ## Automated PR
-
-          This PR was automatically created by the alloy-sysext-build CI pipeline after successfully building and publishing Alloy ${VERSION}.
-
-          ## Test plan
-
-          - [ ] Review the version and hash changes in ghost.bu
-          - [ ] Merge PR to trigger deployment
-          - [ ] Verify Alloy version on instance: \`alloy --version\`
-          - [ ] Verify Alloy service status: \`systemctl status alloy\`
-
-          ## Related
-
-          - Sysext image: https://ghost-sysext-images.separationofconcerns.dev/alloy-${VERSION}-amd64.raw
-          - Alloy release: https://github.com/grafana/alloy/releases/tag/v${VERSION}
-          EOF
-          )")
+            --body "${PR_BODY}")
 
           echo "PR created: ${PR_URL}"
 


### PR DESCRIPTION
## Summary

- Fixes PR body formatting so task list checkboxes are interactive
- Builds PR body in a variable without heredoc indentation

## Context

The heredoc in the previous implementation included leading spaces from YAML indentation, which caused GitHub task list checkboxes (`- [ ]`) to not be clickable/interactive.

Now builds the PR body in a `PR_BODY` variable with content starting at column 0, then passes it to `gh pr create`.

## Test plan

- [ ] Merge this PR
- [ ] On next automated run, verify checkboxes in ghost-stack PR are interactive