### PR TITLE
fix: YAML parsing error from unindented PR body content

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -299,26 +299,27 @@ jobs:
 
           # Create PR
           echo "Creating pull request..."
-          PR_BODY="## Summary
-
-- Updates Grafana Alloy sysext from ${CURRENT_VERSION} to ${VERSION}
-- Updates SHA256 hash to \`${HASH}\`
-
-## Automated PR
-
-This PR was automatically created by the alloy-sysext-build CI pipeline after successfully building and publishing Alloy ${VERSION}.
-
-## Test plan
-
-- [ ] Review the version and hash changes in ghost.bu
-- [ ] Merge PR to trigger deployment
-- [ ] Verify Alloy version on instance: \`alloy --version\`
-- [ ] Verify Alloy service status: \`systemctl status alloy\`
-
-## Related
-
-- [Alloy Release](https://github.com/grafana/alloy/releases/tag/v${VERSION})
-- [Sysext Image](https://ghost-sysext-images.separationofconcerns.dev/alloy-${VERSION}-amd64.raw)"
+          printf -v PR_BODY '%s\n' \
+            "## Summary" \
+            "" \
+            "- Updates Grafana Alloy sysext from ${CURRENT_VERSION} to ${VERSION}" \
+            "- Updates SHA256 hash to \`${HASH}\`" \
+            "" \
+            "## Automated PR" \
+            "" \
+            "This PR was automatically created by the alloy-sysext-build CI pipeline." \
+            "" \
+            "## Test plan" \
+            "" \
+            "- [ ] Review the version and hash changes in ghost.bu" \
+            "- [ ] Merge PR to trigger deployment" \
+            "- [ ] Verify Alloy version on instance: \`alloy --version\`" \
+            "- [ ] Verify Alloy service status: \`systemctl status alloy\`" \
+            "" \
+            "## Related" \
+            "" \
+            "- [Alloy Release](https://github.com/grafana/alloy/releases/tag/v${VERSION})" \
+            "- [Sysext Image](https://ghost-sysext-images.separationofconcerns.dev/alloy-${VERSION}-amd64.raw)"
 
           PR_URL=$(gh pr create \
             --repo ${REPO} \


### PR DESCRIPTION
## Summary

Fixes the YAML syntax error on line 303 that was preventing the workflow from being parsed.

## Problem

The multiline shell string assignment for `PR_BODY` had content starting at column 1 (no indentation):

```yaml
          PR_BODY="## Summary

- Updates Grafana Alloy...   # <-- YAML parser sees this as a list item
```

The YAML parser interpreted the dash characters as YAML list items instead of shell string content, causing the workflow file to fail validation.

## Solution

Use `printf -v` with properly indented arguments to build the PR body. This keeps all content within the YAML block scalar's indentation level, avoiding parser confusion.

## Test plan

- [x] Merge PR
- [x] Verify workflow name shows as "Build and Publish Alloy Sysext" (not the file path)
- [x] Trigger workflow manually to verify it runs