### PR TITLE
[GHO-38] Document GitHub App setup and private key rotation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,23 +82,116 @@ Triggered by:
 | Secret | Purpose |
 |--------|---------|
 | `BWS_ACCESS_TOKEN` | Bitwarden Secrets Manager access |
-| `GHOST_STACK_PAT` | Personal Access Token for creating PRs in ghost-stack |
+| `APP_ID` | GitHub App ID for alloy-sysext-automation |
+| `APP_PRIVATE_KEY` | GitHub App private key (PEM format) |
 
 R2 credentials are retrieved at runtime from Bitwarden (not stored in GitHub).
 
-### Creating GHOST_STACK_PAT
+### GitHub App: alloy-sysext-automation
 
-The PAT needs permission to create branches and PRs in ghost-stack (public repository):
-- `public_repo` (under `repo` scope - access public repositories only)
+The workflow uses a GitHub App to create PRs in ghost-stack with verified commits. This is preferred over a PAT because:
+- Commits are signed/verified by GitHub automatically
+- No token expiration to manage
+- Granular permissions scoped to specific repositories
+- Actions performed are attributed to the app, not a user
 
-To create:
-1. Go to https://github.com/settings/tokens
-2. Generate new token (classic)
-3. Under `repo` scope, select only `public_repo`
-4. Set expiration to 90 days
-5. Add as repository secret named `GHOST_STACK_PAT`
+**App Configuration:**
+- **App Name:** alloy-sysext-automation
+- **App URL:** https://github.com/apps/alloy-sysext-automation
+- **Owner:** noahwhite
+- **Installed on:** noahwhite/ghost-stack
 
-**Rotation:** This token expires every 90 days. See `ghost-stack/docs/token-rotation-runbook.md` for rotation procedure.
+**Permissions Required:**
+| Permission | Access | Purpose |
+|------------|--------|---------|
+| Contents | Read & Write | Create branches and commits |
+| Pull requests | Read & Write | Create and update PRs |
+| Metadata | Read | Required for API access |
+
+### Creating the GitHub App
+
+1. Go to https://github.com/settings/apps/new
+2. Fill in:
+   - **App name:** `alloy-sysext-automation`
+   - **Homepage URL:** `https://github.com/noahwhite/alloy-sysext-build`
+   - **Webhook:** Uncheck "Active" (not needed)
+3. Set permissions:
+   - Repository permissions → Contents: Read & Write
+   - Repository permissions → Pull requests: Read & Write
+   - Repository permissions → Metadata: Read
+4. Select "Only on this account"
+5. Click "Create GitHub App"
+6. Note the **App ID** displayed on the app settings page
+7. Generate a private key (see below)
+8. Install the app on the ghost-stack repository
+
+### Generating the Private Key
+
+1. Go to https://github.com/settings/apps/alloy-sysext-automation
+2. Scroll to "Private keys" section
+3. Click "Generate a private key"
+4. A `.pem` file will be downloaded
+5. Store the entire PEM content (including BEGIN/END lines) as the `APP_PRIVATE_KEY` secret
+
+### Adding Secrets to Repository
+
+```bash
+# Using GitHub CLI
+gh secret set APP_ID --repo noahwhite/alloy-sysext-build
+# Enter the numeric App ID when prompted
+
+gh secret set APP_PRIVATE_KEY --repo noahwhite/alloy-sysext-build < path/to/private-key.pem
+```
+
+Or via GitHub UI:
+1. Go to https://github.com/noahwhite/alloy-sysext-build/settings/secrets/actions
+2. Click "New repository secret"
+3. Add `APP_ID` with the numeric App ID value
+4. Add `APP_PRIVATE_KEY` with the full PEM file contents
+
+### Rotating the Private Key
+
+Private keys don't expire, but should be rotated if compromised or as part of security hygiene.
+
+**Rotation Procedure:**
+
+1. **Generate new key:**
+   - Go to https://github.com/settings/apps/alloy-sysext-automation
+   - Scroll to "Private keys"
+   - Click "Generate a private key"
+   - Download the new `.pem` file
+
+2. **Update the secret:**
+   ```bash
+   gh secret set APP_PRIVATE_KEY --repo noahwhite/alloy-sysext-build < new-private-key.pem
+   ```
+
+3. **Verify the workflow works:**
+   - Trigger a manual workflow run to test
+   - Verify a PR is created in ghost-stack with a verified commit
+
+4. **Revoke the old key:**
+   - Go to https://github.com/settings/apps/alloy-sysext-automation
+   - Find the old key in "Private keys" section
+   - Click "Revoke" next to the old key
+
+**Note:** You can have multiple active private keys during rotation, allowing zero-downtime key rotation.
+
+### Troubleshooting
+
+**"Resource not accessible by integration" error:**
+- The app may not be installed on the target repository
+- Go to https://github.com/settings/apps/alloy-sysext-automation/installations
+- Ensure ghost-stack is in the list of installed repositories
+
+**"Bad credentials" error:**
+- The private key may be incorrectly formatted
+- Ensure the entire PEM content is stored, including `-----BEGIN RSA PRIVATE KEY-----` and `-----END RSA PRIVATE KEY-----` lines
+- Check for trailing newlines or whitespace issues
+
+**Commits not showing as verified:**
+- This shouldn't happen with the GitHub App approach
+- Verify the commit was made via the Contents API, not git push
 
 ## Building Locally
 


### PR DESCRIPTION
## Summary

Updates CLAUDE.md to document the GitHub App (`alloy-sysext-automation`) used for creating verified commits in ghost-stack PRs.

## Changes

Replaces the outdated `GHOST_STACK_PAT` documentation with:

- **App Configuration:** Name, URL, owner, installation details
- **Permissions Required:** Contents, Pull requests, Metadata
- **Creating the GitHub App:** Step-by-step guide
- **Generating the Private Key:** How to create and store keys
- **Adding Secrets:** CLI and UI methods
- **Rotating the Private Key:** Zero-downtime rotation procedure
- **Troubleshooting:** Common error messages and solutions

## Test plan

- [x] Review documentation for accuracy and completeness