### PR TITLE
fix: skip PR creation when version is already current in ghost.bu

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -253,6 +253,12 @@ jobs:
             exit 1
           fi
 
+          # Check if version is already current - skip PR creation
+          if [ "${CURRENT_VERSION}" = "${VERSION}" ]; then
+            echo "✓ Version ${VERSION} is already in ghost.bu, skipping PR creation"
+            exit 0
+          fi
+
           echo "Updating from ${CURRENT_VERSION} to ${VERSION}"
 
           # Extract the current Alloy hash (appears after the alloy source URL)


### PR DESCRIPTION
## Summary

Adds checks to skip the workflow when a version has already been built and released.

## Problem

The workflow was:
1. Rebuilding and re-uploading to R2 for versions that already had a release tag
2. Creating duplicate PRs (e.g., "Update from 1.13.0 to 1.13.0") when the version was already in ghost.bu

## Solution

Two-level skip logic:

1. **Early skip (build job)**: After determining the version, check if a release tag already exists. If so, skip all build steps and the publish job entirely. This only applies to `workflow_dispatch` - release events proceed normally since the release is what we're building.

2. **PR skip (publish job)**: Before creating the ghost-stack PR, compare the current version in ghost.bu with the target version. If they match, skip PR creation.

## Test plan

- [ ] Trigger workflow manually with a version that already has a release tag → should skip entirely
- [ ] Trigger workflow manually with a new version → should build and publish
- [ ] Trigger via release event → should build and publish (even if release exists, since it's the trigger)
- [ ] Verify PR is not created when ghost.bu already has the target version