### PR TITLE
fix: skip entire workflow when version already released

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -23,6 +23,7 @@ jobs:
 
     outputs:
       version: ${{ steps.version.outputs.version }}
+      skip: ${{ steps.check-release.outputs.skip }}
 
     steps:
       - name: Checkout repository
@@ -42,10 +43,35 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Building Alloy sysext for version: ${VERSION}"
 
+      - name: Check if version already released
+        id: check-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Skip this check if triggered by a release event (the release is what we're building)
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "Triggered by release event, proceeding with build"
+            echo "skip=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # For workflow_dispatch, check if release already exists
+          if gh release view "v${VERSION}" &>/dev/null; then
+            echo "✓ Release v${VERSION} already exists, skipping build"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "Release v${VERSION} does not exist, proceeding with build"
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set up Docker Buildx
+        if: steps.check-release.outputs.skip != 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Build Docker image
+        if: steps.check-release.outputs.skip != 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -55,9 +81,11 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Create output directory
+        if: steps.check-release.outputs.skip != 'true'
         run: mkdir -p output
 
       - name: Build sysext image
+        if: steps.check-release.outputs.skip != 'true'
         run: |
           docker run --rm \
             -v "${PWD}/output:/output" \
@@ -67,9 +95,11 @@ jobs:
             /build/build-alloy-sysext.sh
 
       - name: List output files
+        if: steps.check-release.outputs.skip != 'true'
         run: ls -la output/
 
       - name: Validate sysext structure
+        if: steps.check-release.outputs.skip != 'true'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           SYSEXT_FILE="output/alloy-${VERSION}-amd64.raw"
@@ -116,6 +146,7 @@ jobs:
           echo "=== Validation passed ==="
 
       - name: Verify checksums
+        if: steps.check-release.outputs.skip != 'true'
         run: |
           cd output
           echo "=== Verifying checksums ==="
@@ -124,6 +155,7 @@ jobs:
           echo "=== Checksums verified ==="
 
       - name: Upload artifacts
+        if: steps.check-release.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: alloy-sysext-${{ steps.version.outputs.version }}
@@ -135,7 +167,7 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'release' || github.event_name == 'workflow_dispatch') && needs.build.outputs.skip != 'true'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

For `workflow_dispatch` triggers, check if a release tag already exists for the specified version. If so, skip all build and publish steps entirely.

## Problem

When manually triggering the workflow for a version that was already built and released, the workflow would:
1. Rebuild the sysext image (unnecessary work)
2. Re-upload to R2 (overwriting identical files)
3. Attempt to create a PR (now skipped by PR #28, but still wasteful)

## Solution

Add an early check after version determination:
- For `workflow_dispatch`: Check if `v{VERSION}` release tag exists, skip if so
- For `release` events: Always proceed (the release is what triggered us)

All subsequent build steps and the publish job check the `skip` output and exit early if the version is already released.

## Test plan

- [x] Trigger workflow manually with version `1.13.0` (already released) → should skip with "Release v1.13.0 already exists"
- [ ] Trigger workflow manually with a new version → should build normally
- [ ] Create a new release → should build normally (release events bypass the check)