### PR TITLE
Add GPG signature verification for sysext images

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -154,6 +154,42 @@ jobs:
           sha256sum -c alloy-${{ steps.version.outputs.version }}.raw.sha256
           echo "=== Checksums verified ==="
 
+      - name: Import GPG signing key
+        if: steps.check-release.outputs.skip != 'true'
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          echo "=== Importing GPG signing key ==="
+          echo "${GPG_PRIVATE_KEY}" | base64 -d | gpg --batch --import
+
+          # Get the key ID for signing
+          KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep sec | head -1 | awk '{print $2}' | cut -d'/' -f2)
+          echo "GPG Key ID: ${KEY_ID}"
+          echo "gpg_key_id=${KEY_ID}" >> $GITHUB_ENV
+
+      - name: Sign sysext images
+        if: steps.check-release.outputs.skip != 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          echo "=== Signing sysext images ==="
+
+          # Sign the versioned amd64 image
+          gpg --batch --yes --armor --detach-sign \
+            --local-user "${gpg_key_id}" \
+            "output/alloy-${VERSION}-amd64.raw"
+          echo "✓ Signed alloy-${VERSION}-amd64.raw"
+
+          # Sign the compatibility symlink target (same file, different name)
+          gpg --batch --yes --armor --detach-sign \
+            --local-user "${gpg_key_id}" \
+            "output/alloy-${VERSION}.raw"
+          echo "✓ Signed alloy-${VERSION}.raw"
+
+          # List all output files including signatures
+          echo "=== Output files ==="
+          ls -la output/
+
       - name: Upload artifacts
         if: steps.check-release.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
@@ -162,6 +198,7 @@ jobs:
           path: |
             output/*.raw
             output/*.sha256
+            output/*.asc
           retention-days: 30
 
   publish:
@@ -212,8 +249,8 @@ jobs:
 
           echo "=== Uploading to R2 bucket ==="
 
-          # Upload files to R2
-          for file in output/*.raw output/*.sha256; do
+          # Upload files to R2 (including .asc signature files)
+          for file in output/*.raw output/*.sha256 output/*.asc; do
             filename=$(basename "$file")
             echo "Uploading ${filename}..."
             aws s3 cp "$file" "s3://${R2_BUCKET}/${filename}" \


### PR DESCRIPTION
## Summary

Adds GPG signing to the sysext build pipeline for cryptographic verification by systemd-sysupdate.

## Changes

### build-and-publish.yml
- Import GPG private key from `GPG_PRIVATE_KEY` secret
- Sign sysext images with `gpg --armor --detach-sign`
- Upload `.asc` signature files to R2 alongside images

### CLAUDE.md
- Document GPG key generation procedure
- Document key rotation procedure
- Update output files list to include signatures

## Prerequisites

Before merging, the following must be completed:

1. **Generate GPG key pair:**
   ```bash
   gpg --batch --gen-key <<EOF
   Key-Type: RSA
   Key-Length: 4096
   Name-Real: Alloy Sysext Signing Key
   Name-Email: alloy-sysext@separationofconcerns.dev
   Expire-Date: 0
   %no-protection
   EOF
   ```

2. **Add private key to GitHub secrets:**
   ```bash
   gpg --armor --export-secret-keys alloy-sysext@separationofconcerns.dev | base64 -w 0 > gpg-private-key.b64
   gh secret set GPG_PRIVATE_KEY --repo noahwhite/alloy-sysext-build < gpg-private-key.b64
   ```

3. **Export public key for ghost-stack:**
   ```bash
   gpg --armor --export alloy-sysext@separationofconcerns.dev > alloy-sysext-signing.pub
   ```

## Follow-up Work

A separate PR in ghost-stack is needed to:
- Deploy the public key via Ignition
- Update sysupdate config with `Verify=true`

## Test plan

- [x] Generate GPG key pair
- [x] Add `GPG_PRIVATE_KEY` secret to repository
- [ ] Trigger a manual workflow run
- [ ] Verify `.asc` files are created and uploaded to R2
- [ ] Verify signatures can be validated with public key

Closes GHO-58 (partial)