### PR TITLE
Fix: Remove GHO-21 from automated PR branch names

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -317,7 +317,7 @@ jobs:
         run: |
           VERSION="${{ needs.build.outputs.version }}"
           HASH="${{ steps.hash.outputs.sha256 }}"
-          BRANCH="feature/GHO-21-update-alloy-to-${VERSION}"
+          BRANCH="feature/update-alloy-sysext-to-${VERSION}"
           REPO="noahwhite/ghost-stack"
           FILE_PATH="opentofu/modules/vultr/instance/userdata/ghost.bu"
 


### PR DESCRIPTION
## Summary

Removes the hardcoded `GHO-21` reference from automated PR branch names.

## Problem

The branch name `feature/GHO-21-update-alloy-to-X` was causing Linear's GitHub integration to incorrectly change GHO-21's state whenever an automated PR was created or merged. This story was completed long ago but kept getting reopened.

## Solution

Changed branch naming from:
```
feature/GHO-21-update-alloy-to-${VERSION}
```

To:
```
feature/update-alloy-sysext-to-${VERSION}
```

This follows the `feature/**` branch convention (required by ghost-stack CI) without referencing a specific Linear issue.

## Test plan

- [ ] Merge this PR
- [ ] Trigger a new Alloy build
- [ ] Verify the ghost-stack PR branch name doesn't include "GHO-21"
- [ ] Verify GHO-21 state is not affected in Linear
