### PR TITLE
GHO-95: Fix duplicate tracking issue creation in check-new-releases workflow

### DIFF
--- a/.github/workflows/check-new-releases.yml
+++ b/.github/workflows/check-new-releases.yml
@@ -120,6 +120,18 @@ jobs:
           VERSION="${{ steps.latest.outputs.version }}"
           RELEASE_NOTES=$(cat /tmp/release_notes.txt | head -50)
 
+          # Skip if an open issue already exists for this version
+          EXISTING=$(gh issue list \
+            --search "\"Alloy ${VERSION} sysext build triggered\" in:title" \
+            --state open \
+            --json number \
+            --jq 'length')
+
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "Issue already exists for Alloy ${VERSION}, skipping creation"
+            exit 0
+          fi
+
           gh issue create \
             --title "Alloy ${VERSION} sysext build triggered" \
             --body "$(cat <<EOF


### PR DESCRIPTION
## Summary

- Adds a deduplication check to the "Create tracking issue" step in `check-new-releases.yml`
- Before creating a new issue, the workflow now queries for any existing open issue with the same title (`"Alloy {VERSION} sysext build triggered"`)
- If one exists, issue creation is skipped with a log message

## Root cause

When a build fails before creating the release tag (e.g. due to expired `BWS_ACCESS_TOKEN`), the next day's `check-new-releases` run still sees the version as "new" (no release exists) and triggers the build again — and creates another duplicate tracking issue. This repeated daily until the underlying build failure is fixed.

## What this does NOT fix

The current 1.13.2 build failure is caused by an expired `BWS_ACCESS_TOKEN` secret in this repo's GitHub Actions secrets. That requires a manual token rotation per the [token rotation runbook](https://github.com/noahwhite/ghost-stack/blob/develop/docs/token-rotation-runbook.md#bitwarden-secrets-manager-bws-access-token). Once rotated, re-triggering the build manually will complete successfully.

## Test plan

- [ ] After merge, verify the next midnight run does not create a duplicate issue for 1.13.2 (assuming build still failing) — workflow log should show "Issue already exists for Alloy 1.13.2, skipping creation"
- [ ] After rotating `BWS_ACCESS_TOKEN` and manually triggering the build, verify the 1.13.2 release tag is created and the ghost-stack PR is opened