### PR TITLE
GHO-105: add RTB label to automated sysext tracking issues

### DIFF
--- a/.github/workflows/check-new-releases.yml
+++ b/.github/workflows/check-new-releases.yml
@@ -134,6 +134,7 @@ jobs:
 
           gh issue create \
             --title "Alloy ${VERSION} sysext build triggered" \
+            --label "RTB" \
             --body "$(cat <<EOF
           ## Automated Build Triggered
 


### PR DESCRIPTION
## Summary

Adds `--label "RTB"` to the `gh issue create` call in `check-new-releases.yml` so that all automated Alloy sysext tracking issues are tagged as run-the-business work in Linear.

The RTB GitHub label already exists in this repo. Linear's GitHub integration maps GitHub labels to Linear workspace labels by name match — no additional Linear configuration needed.

## Test plan

- [ ] Next automated tracking issue (or manually triggered dry-run followed by a real run) is created with the RTB label applied in both GitHub and Linear