### PR TITLE
chore: upgrade actions/create-github-app-token from v1 to v3

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -241,7 +241,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Upgrades `actions/create-github-app-token` from v1 to v3 to resolve the Node.js 20 deprecation warning in GitHub Actions runners.

> Node.js 20 actions are deprecated. Please update the following actions to use Node.js 24: actions/create-github-app-token@v1